### PR TITLE
Chore: NarBar visual display improvement

### DIFF
--- a/src/components/nav_bar/nav_bar.jsx
+++ b/src/components/nav_bar/nav_bar.jsx
@@ -6,7 +6,10 @@ import { motion, AnimatePresence } from "framer-motion";
 export default function NavBar({ isOpen, setIsOpen }) {
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const navClasses = `${isOpen ? "blur-sm pointer-events-none" : ""} fixed top-0 left-0 right-0 z-40 bg-lime-100`;
+  const navClasses = `${isOpen ? "blur-sm pointer-events-none" : ""} 
+    fixed top-0 left-0 right-0 z-40 
+    bg-gradient-to-r from-lime-100 via-emerald-100 to-lime-200 
+    shadow-md rounded-b-2xl`;
 
   // Animation variants for bubble buttons
   const itemVariants = {
@@ -22,17 +25,21 @@ export default function NavBar({ isOpen, setIsOpen }) {
 
   return (
     <nav className={navClasses}>
-      <div className="relative h-20 flex items-center justify-center px-4">
+      <div className="relative h-20 flex items-center justify-center px-6">
         {/* Left: Hamburger Menu */}
-        <div className="absolute left-0 flex items-center gap-2">
+        <div className="absolute left-4 flex items-center">
           <div className="relative">
-            {/* Hamburger Button */}
-            <FaBars
-              className="w-7 h-7 text-black cursor-pointer hover:text-green-600 transition-colors"
+           {/* When you hover to the button have a little zoom in animation*/}
+            <motion.div
+              whileTap={{ scale: 0.9 }}
+              whileHover={{ scale: 1.1 }}
+              className="p-2 rounded-full bg-white shadow hover:bg-emerald-50 cursor-pointer"
               onClick={() => setMenuOpen((prev) => !prev)}
-            />
+            >
+              <FaBars className="w-6 h-6 text-emerald-700" />
+            </motion.div>
 
-            {/* Bubble Menu */}
+            {/* Bubble Menu*/}
             <AnimatePresence>
               {menuOpen && (
                 <motion.div
@@ -40,14 +47,12 @@ export default function NavBar({ isOpen, setIsOpen }) {
                   animate={{ opacity: 1, scale: 1 }}
                   exit={{ opacity: 0, scale: 0.9 }}
                   transition={{ duration: 0.2 }}
-                  className="absolute top-10 left-0 bg-white shadow-md rounded-xl p-3 flex flex-col gap-3"
+                  className="absolute top-12 left-0 bg-white shadow-lg rounded-xl p-3 flex flex-col gap-3"
                 >
-                  {/*These are what is inside the hamburger button. motion.button allows the creation and animation of the bubble*/}
                   {[
                     { icon: <FaHome />, label: "Home" },
                     { icon: <FaUser />, label: "Login" },
                     { icon: <FaHeart />, label: "Favorites" },
-                    
                   ].map((item, i) => (
                     <motion.button
                       key={item.label}
@@ -56,7 +61,7 @@ export default function NavBar({ isOpen, setIsOpen }) {
                       initial="hidden"
                       animate="visible"
                       exit="exit"
-                      className="flex items-center gap-2 text-gray-700 hover:text-green-600 text-sm"
+                      className="flex items-center gap-2 text-gray-700 hover:text-emerald-600 hover:translate-x-1 transition-transform text-sm"
                     >
                       {item.icon} {item.label}
                     </motion.button>
@@ -69,16 +74,20 @@ export default function NavBar({ isOpen, setIsOpen }) {
 
         {/* Center: Logo & Title */}
         <div className="flex items-center gap-2">
-          <img src={LeafImg} alt="Leaf" className="w-6 h-6 object-contain" />
-          <span className="text-xl font-bold text-gray-800">EarthMed</span>
+          <img src={LeafImg} alt="Leaf" className="w-7 h-7 object-contain" />
+          <span className="text-2xl font-bold text-emerald-900">EarthMed</span>
         </div>
 
-        {/* Right: FilterBox Position */}
-        <div className="absolute right-0 flex items-center p-10">
-          <FaFilter
-            className="w-6 h-6 text-black hover:text-green-600 transition-colors"
-            onClick={() => setIsOpen(true)}
-          />
+        {/* Right: Filter Icon*/}
+        <div className="absolute right-6 flex items-center">
+         {/*Add a little animation when the mouse gets close to it*/}
+          <motion.div
+            whileHover={{ scale: 1.15 }}
+            whileTap={{ scale: 0.9 }}
+            className="p-2 rounded-full bg-white shadow hover:bg-emerald-50 cursor-pointer"
+            onClick={() => setIsOpen(true)}>
+            <FaFilter className="w-5 h-5 text-emerald-700" />
+          </motion.div>
         </div>
       </div>
     </nav>


### PR DESCRIPTION
- Softer earth-tone gradient background instead of flat lime (muted greens + cream) for better visual apperance.
- Subtle shadow and rounded edges to make it float above content.
- Moved the hamburger menu slightly inwards (not hugging the left edge) like before.
- Improve the filter icon styling (rounded button with background hover effect instead of plain color change) since it looked boring.
- Kept the logo + title centered, but made the text slightly softer not choppy, kept it black though.
- Add hover scale effects for icons for users to know if it is clickable.